### PR TITLE
Remove spurious forwardedHeaderTransformer queue creation and connection

### DIFF
--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -4,6 +4,11 @@ spring:
 
   cloud:
     stream:
+      function:
+        # needed otherwise ForwardedHeaderTransformer from spring-webflux
+        # server.forward-headers-strategy=FRAMEWORK is spuriously setup
+        # as a consumer and creating useless queues and connections
+        autodetect: false
       bindings:
         publishConfigUpdate-out-0:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}config.update


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
We have a spurious queue forwardedHeaderTransformer-in-0 (and connection to it)

NOTE: when I send a messsage to it, we get 
```
java.lang.ClassCastException: class [B cannot be cast to class org.springframework.http.server.reactive.ServerHttpRequest ([B is in module java.base of loader 'bootstrap'; org.springframework.http.server.reactive.ServerHttpRequest is in unnamed module of loader 'app')
```

Basically we have to set autodetect to false in webflux server
when using server.forward-headers-strategy=FRAMEWORK
otherwise the created bean to implement the forward header strategy
(which is actually of type Function<HttpServletRequest, HttpServletRequest>)
gets used as a queue processing function by spring cloud stream

